### PR TITLE
Add CI tests + config files

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,15 +3,44 @@ name: Validate
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   validate:
+    name: Validate HACS App
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - name: Checkout
+        uses: "actions/checkout@v2"
+
+      - name: Ignore issues and topics for non-main branch
+        if: github.ref != 'refs/heads/master'
+        run: echo 'IGNORE=issues topics' >> "$GITHUB_ENV"
+
       - name: HACS validation
         uses: "hacs/action@main"
         with:
           category: "appdaemon"
+          comment: "false"
+          ignore: "${{ env.IGNORE }}"
+
+  tests:
+    name: Tests & Linting
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: "actions/checkout@v2"
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run pytest
+        run: pytest
+
+      - name: Run linting with autopep8
+        if: always()
+        run: autopep8 --diff --recursive --exit-code .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 venv
 .pytest_cache
+__pycache__
 
 tests/secrets.py

--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[pycodestyle]
+max_line_length = 160
+aggressive = 1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "autopep8"
+}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Spotify Mood Lights Sync
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
+
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs) [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NiklasReiche/ad-spotify-mood-lights-sync/Validate?style=for-the-badge)](https://github.com/NiklasReiche/ad-spotify-mood-lights-sync/actions)
 
 _AppDaemon app that synchronizes rgb lights to the mood of the currently playing spotify song in Home Assistant._
 
 ## About
-This app uses the Spotify API to extract the emotional mood value of the currently playing track. Each mood value lies on a 2D plane which is mapped to a color spectrum from which the rgb color for the light is picked. 
+
+This app uses the Spotify API to extract the emotional mood value of the currently playing track. Each mood value lies on a 2D plane which is mapped to a color spectrum from which the rgb color for the light is picked.
 
 The default color map used by the app looks as follows. The horizontal axis ranges from negative (left) to positive (right) emotion while the vertical axis ranges from weak (bottom) to high (top) energy. A sad, slow song is thus mapped to blue light while a happy, upbeat song is mapped to yellow light.
 
 <img src="https://github.com/NiklasReiche/ha-spotify-lights-sync/blob/master/examples/default_profile.png" alt="default color profile" width="200">
 
 ## Prerequisites
+
 For this app to work, the following python packages must be installed in the AppDaemon environment:
 
 - spotipy
@@ -21,6 +24,7 @@ If you wish to view the color map currently in use for debugging color profiles,
 - Pillow
 
 You may need to also specify the following system packages depending on your system setup:
+
 ```yaml
 system_packages:
   - jpeg
@@ -28,12 +32,15 @@ system_packages:
 ```
 
 ## Issues
+
 Since the Spotify integration in Home Assistant only polls the Spotify API every 30 seconds or so to detect when the currently playing song changes, the light synchronization may be delayed by up to 30 seconds in the worst case.
 
 ## Installation
+
 Use [HACS](https://hacs.xyz/) or download the `spotify_mood_lights_sync` directory from inside the `apps` directory here to your local `apps` directory, then add the configuration to enable the `spotify_mood_lights_sync` module.
 
 #### Minimal configuration:
+
 ```yaml
 spotify_mood_lights_sync:
   module: spotify_mood_lights_sync
@@ -45,6 +52,7 @@ spotify_mood_lights_sync:
 ```
 
 ## App configuration
+
 ```yaml
 spotify_mood_lights_sync:
   module: spotify_mood_lights_sync
@@ -69,26 +77,28 @@ spotify_mood_lights_sync:
     location: /home/homeassistant/.homeassistant/www/spotify-lights-sync/test.png
 ```
 
-| key                       | optional | type   | default     | description                                            |
-|---------------------------|----------|--------|-------------|--------------------------------------------------------|
-|`module`                   | False    | string |             | The module name of the app. |
-|`class`                    | False    | string |             | The name of the Class. |
-|`client_id`                | False    | string |             | The client id of the Spotify-For-Developers app to use for accessing the Spotify API. |
-|`client_secret`            | False    | string |             | The client secret of the Spotify-For-Developers app to use for accessing the Spotify API. |
-|`media_player`             | False    | string |             | The entity_id of the media player to sync from. Must be a spotify media player. |
-|`light`                    | False    | string |             | The entity_id of the light or light group to sync. |
-|`color_profile`            | True     | string | `default`   | The color profile to use for mapping moods to colors. Possible values are `default`, `centered`, or `custom`. When `custom` is specified, the color map will be built from the point-color pairs provided in `custom_profile`. |
-|`custom_profile`           | True     | object |             | A list of point-color pairs to use for the `custom` `color_profile`. |
-|`custom_profile.point`     | False    | tuple  |             | A point in the [0, 1]X[0, 1] range. |
-|`custom_profile.color`     | False    | tuple  |             | A rgb color value. |
-|`debug`                    | True     | bool   | `false`     | Log spotify track metadata and color information for debugging. |
-|`color_map_image`          | True     | object |             | Output the color map as an image for debugging. |
-|`color_map_image.size`     | False    | number |             | Size (height=width) of the output image in pixels. |
-|`color_map_image.location` | False    | string |             | Path to which the image should be saved. |
+| key                        | optional | type   | default   | description                                                                                                                                                                                                                    |
+| -------------------------- | -------- | ------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `module`                   | False    | string |           | The module name of the app.                                                                                                                                                                                                    |
+| `class`                    | False    | string |           | The name of the Class.                                                                                                                                                                                                         |
+| `client_id`                | False    | string |           | The client id of the Spotify-For-Developers app to use for accessing the Spotify API.                                                                                                                                          |
+| `client_secret`            | False    | string |           | The client secret of the Spotify-For-Developers app to use for accessing the Spotify API.                                                                                                                                      |
+| `media_player`             | False    | string |           | The entity_id of the media player to sync from. Must be a spotify media player.                                                                                                                                                |
+| `light`                    | False    | string |           | The entity_id of the light or light group to sync.                                                                                                                                                                             |
+| `color_profile`            | True     | string | `default` | The color profile to use for mapping moods to colors. Possible values are `default`, `centered`, or `custom`. When `custom` is specified, the color map will be built from the point-color pairs provided in `custom_profile`. |
+| `custom_profile`           | True     | object |           | A list of point-color pairs to use for the `custom` `color_profile`.                                                                                                                                                           |
+| `custom_profile.point`     | False    | tuple  |           | A point in the [0, 1]X[0, 1] range.                                                                                                                                                                                            |
+| `custom_profile.color`     | False    | tuple  |           | A rgb color value.                                                                                                                                                                                                             |
+| `debug`                    | True     | bool   | `false`   | Log spotify track metadata and color information for debugging.                                                                                                                                                                |
+| `color_map_image`          | True     | object |           | Output the color map as an image for debugging.                                                                                                                                                                                |
+| `color_map_image.size`     | False    | number |           | Size (height=width) of the output image in pixels.                                                                                                                                                                             |
+| `color_map_image.location` | False    | string |           | Path to which the image should be saved.                                                                                                                                                                                       |
 
 ### Conditional execution
+
 You can switch the light synchronization on and off through Home Assistant by using AppDaemon [Callback Constraints](https://appdaemon.readthedocs.io/en/latest/APPGUIDE.html#hass-plugin-constraints).
 For example, you can control the execution with an `input_boolean` switch:
+
 ```yaml
 spotify_lights_sync:
   ...
@@ -97,11 +107,14 @@ spotify_lights_sync:
 ```
 
 ### Custom color profile
+
 You can create your own color profile for the app to use by specifying the `custom_profile` app argument and setting `color_profile` to `custom`.
 In order to create a color map the app expects a list of points on the 2D plane with a corresponding rgb color for each point. The color value for a song can then be interpolated from the given colors based on where the mood value of that song lies on the 2D plane.
 The mood of a song is a 2-dimensional value in the range [0.0,1.0]x[0.0,1.0] where the first axis is the valence, and the second axis the energy of the song. See the [Spotify API](https://developer.spotify.com/documentation/web-api/reference/#object-audiofeaturesobject) for more information on these values.
 
 ## Acknowledgments
+
 This project is based on the following projects:
+
 - https://github.com/ericmatte/ad-media-lights-sync
 - https://github.com/tyiannak/color_your_music_mood

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+appdaemontestframework
+autopep8
+pytest
+spotipy
+numpy

--- a/tests/spotify_lights_sync_test.py
+++ b/tests/spotify_lights_sync_test.py
@@ -1,12 +1,11 @@
 from appdaemontestframework import automation_fixture
-import secrets
 from apps.spotify_mood_lights_sync.spotify_mood_lights_sync import SpotifyMoodLightsSync
 
 
 @automation_fixture(SpotifyMoodLightsSync)
 def uut(given_that):
-    given_that.passed_arg('client_id').is_set_to(secrets.CLIENT_ID)
-    given_that.passed_arg('client_secret').is_set_to(secrets.CLIENT_SECRET)
+    given_that.passed_arg('client_id').is_set_to("TEST_CLIENT_ID")
+    given_that.passed_arg('client_secret').is_set_to("TEST_CLIENT_SECRET")
     given_that.passed_arg('media_player').is_set_to('media_player.spotify_test')
     given_that.passed_arg('light').is_set_to('light.test_light')
 


### PR DESCRIPTION
Hi @NiklasReiche,

First of all, thank you for your interest in my [ad-media-lights-sync](https://github.com/ericmatte/ad-media-lights-sync) project 😄 

I didn't know that you could that easily test AppDaemon apps using `appdaemontestframework`. So now I've added a bunch of tests to my app which is great.

I just thought that I could share with you some of the thing I used in my flow.

### Proposed changes with this PR

- Update GitHub Actions flow to also run tests and linting on every push
- Add autopep8 for auto-formatting and code style convention
- Add `requirements.txt` with the list of all the required packages for contribution
- Add build badge to README.md + auto format

Example run: https://github.com/ericmatte/ad-spotify-mood-lights-sync/actions/runs/591462931

Best regards,

Eric